### PR TITLE
Fix missing db links, change file extension of query files, clean up documentation

### DIFF
--- a/data_creation.sqlite3-query
+++ b/data_creation.sqlite3-query
@@ -1,4 +1,5 @@
--- database: d:\OneDrive - NSW Department of Education\11 SW\VSCode\HomeLaptop\SQL\data_source.db
+-- database: .\data_source.db
+-- Use the ▷ button in the top right corner to run the entire file.
 
 -- We need to create data in publishers and developers first
 -- This is because the data in games has foreign keys to those tables

--- a/sample_queries.sqlite3-query
+++ b/sample_queries.sqlite3-query
@@ -1,3 +1,6 @@
+-- database: .\data_source.db
+-- You can run the queries by clicking the ▷ above a block of code to run just that block
+
 -- select all games
 SELECT * FROM Games;
 

--- a/student_queries.sqlite3-query
+++ b/student_queries.sqlite3-query
@@ -1,9 +1,12 @@
+-- database: .\data_source.db
+
 -- Write and test your queries in the 'Query Editor'
 -- Then save them here
+-- You can run your queries by clicking the ▷ above a block of code to run just that block
+-- Or you can click the ▷ in the top right corner of the text editor to run everything in the file at once 
 
 
 -- 1: Best sellers.   Select game name, publisher name, quantity sold in descending order by quantity sold
-
 
 
 -- 2: Hideo's games.   Select game name, quantity sold, cost, retail price in ascending order by retail price. Restrict to developer first name 'Hideo'
@@ -16,6 +19,7 @@
 
 
 -- 5a: CHALLENGE.   Select game name and a calculated PROFIT field  (Use revenue as quantity * price)
+
 
 -- 5b: CHALLENGE.   Update the above query to be GROUPED BY Developer
 

--- a/table_creation.sqlite3-query
+++ b/table_creation.sqlite3-query
@@ -1,5 +1,4 @@
--- database: d:\OneDrive - NSW Department of Education\11 SW\VSCode\HomeLaptop\SQL\data_source.db
-
+-- database: .\data_source.db
 -- Use the ▷ button in the top right corner to run the entire file.
 
 CREATE TABLE Publishers (


### PR DESCRIPTION
Uses a relative path to always find the db correctly without having students enter the path themself.

Changed the file extension of the queries to .sqlite3-query so the SQLite3 Editor extension will detect them as queries for the database.

Rewrote some of the documentation strings, especially in student_queries to make it clearer and add missing information.